### PR TITLE
feat: 이벤트 리스너 패턴 적용 및 Outbox Publisher 리팩토링

### DIFF
--- a/src/main/java/com/grewmeet/recording/recordingcommandservice/event/DatingParticipationEventListener.java
+++ b/src/main/java/com/grewmeet/recording/recordingcommandservice/event/DatingParticipationEventListener.java
@@ -1,0 +1,50 @@
+package com.grewmeet.recording.recordingcommandservice.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grewmeet.recording.recordingcommandservice.saga.incoming.DatingParticipationReceived;
+import com.grewmeet.recording.recordingcommandservice.saga.outgoing.DatingParticipationRecorded;
+import com.grewmeet.recording.recordingcommandservice.service.OutboxService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class DatingParticipationEventListener {
+
+    private final OutboxService outboxService;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "grewmeet.dating.participation.received", groupId = "recording-command-service")
+    public void handleDatingParticipationReceived(String eventJson) {
+        try {
+            log.info("데이팅 참여 이벤트 수신: {}", eventJson);
+            
+            DatingParticipationReceived receivedEvent = objectMapper.readValue(eventJson, DatingParticipationReceived.class);
+            
+            // 수신 이벤트를 기록용 이벤트로 변환
+            DatingParticipationRecorded recordedEvent = DatingParticipationRecorded.from(receivedEvent);
+            
+            // Outbox를 통해 Query Service로 이벤트 발행
+            outboxService.publishEvent(
+                "DatingParticipationRecorded", 
+                "DatingParticipation", 
+                receivedEvent.participantId(), 
+                recordedEvent
+            );
+            
+            log.info("데이팅 참여 기록 이벤트 발행 완료: participantId={}, userId={}", 
+                    receivedEvent.participantId(), receivedEvent.userId());
+            
+        } catch (JsonProcessingException e) {
+            log.error("데이팅 참여 이벤트 파싱 실패: {}", eventJson, e);
+        } catch (Exception e) {
+            log.error("데이팅 참여 이벤트 처리 실패: {}", eventJson, e);
+        }
+    }
+}

--- a/src/main/java/com/grewmeet/recording/recordingcommandservice/event/StudyParticipationEventListener.java
+++ b/src/main/java/com/grewmeet/recording/recordingcommandservice/event/StudyParticipationEventListener.java
@@ -1,0 +1,50 @@
+package com.grewmeet.recording.recordingcommandservice.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grewmeet.recording.recordingcommandservice.saga.incoming.StudyParticipationReceived;
+import com.grewmeet.recording.recordingcommandservice.saga.outgoing.StudyParticipationRecorded;
+import com.grewmeet.recording.recordingcommandservice.service.OutboxService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class StudyParticipationEventListener {
+
+    private final OutboxService outboxService;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "grewmeet.study.participation.received", groupId = "recording-command-service")
+    public void handleStudyParticipationReceived(String eventJson) {
+        try {
+            log.info("스터디 참여 이벤트 수신: {}", eventJson);
+            
+            StudyParticipationReceived receivedEvent = objectMapper.readValue(eventJson, StudyParticipationReceived.class);
+            
+            // 수신 이벤트를 기록용 이벤트로 변환
+            StudyParticipationRecorded recordedEvent = StudyParticipationRecorded.from(receivedEvent);
+            
+            // Outbox를 통해 Query Service로 이벤트 발행
+            outboxService.publishEvent(
+                "StudyParticipationRecorded", 
+                "StudyParticipation", 
+                receivedEvent.participantId(), 
+                recordedEvent
+            );
+            
+            log.info("스터디 참여 기록 이벤트 발행 완료: participantId={}, userId={}", 
+                    receivedEvent.participantId(), receivedEvent.userId());
+            
+        } catch (JsonProcessingException e) {
+            log.error("스터디 참여 이벤트 파싱 실패: {}", eventJson, e);
+        } catch (Exception e) {
+            log.error("스터디 참여 이벤트 처리 실패: {}", eventJson, e);
+        }
+    }
+}

--- a/src/main/java/com/grewmeet/recording/recordingcommandservice/event/publisher/OutboxPublisher.java
+++ b/src/main/java/com/grewmeet/recording/recordingcommandservice/event/publisher/OutboxPublisher.java
@@ -1,0 +1,9 @@
+package com.grewmeet.recording.recordingcommandservice.event.publisher;
+
+public interface OutboxPublisher {
+    
+    /**
+     * 대기 중인 Outbox 이벤트들을 Kafka로 발행합니다.
+     */
+    void publishPendingEvents();
+}

--- a/src/main/java/com/grewmeet/recording/recordingcommandservice/event/publisher/OutboxPublisherImpl.java
+++ b/src/main/java/com/grewmeet/recording/recordingcommandservice/event/publisher/OutboxPublisherImpl.java
@@ -1,4 +1,4 @@
-package com.grewmeet.recording.recordingcommandservice.service;
+package com.grewmeet.recording.recordingcommandservice.event.publisher;
 
 import com.grewmeet.recording.recordingcommandservice.domain.outbox.Outbox;
 import com.grewmeet.recording.recordingcommandservice.domain.outbox.OutboxStatus;
@@ -13,11 +13,12 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class OutboxPublisher {
+public class OutboxPublisherImpl implements OutboxPublisher {
 
     private final OutboxRepository outboxRepository;
     private final KafkaTemplate<String, String> kafkaTemplate;
 
+    @Override
     @Scheduled(fixedDelay = 5000) // 5초마다 실행
     public void publishPendingEvents() {
         List<Outbox> pendingEvents = outboxRepository.findByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING);

--- a/src/main/java/com/grewmeet/recording/recordingcommandservice/saga/outgoing/DatingParticipationRecorded.java
+++ b/src/main/java/com/grewmeet/recording/recordingcommandservice/saga/outgoing/DatingParticipationRecorded.java
@@ -1,5 +1,7 @@
 package com.grewmeet.recording.recordingcommandservice.saga.outgoing;
 
+import com.grewmeet.recording.recordingcommandservice.saga.incoming.DatingParticipationReceived;
+
 import java.time.LocalDateTime;
 
 public record DatingParticipationRecorded(
@@ -9,4 +11,15 @@ public record DatingParticipationRecorded(
     LocalDateTime participationDate,    // 참여 날짜
     String status,                      // 참여 상태
     LocalDateTime recordedAt            // 기록 생성 시간
-) {}
+) {
+    public static DatingParticipationRecorded from(DatingParticipationReceived received) {
+        return new DatingParticipationRecorded(
+                null,  // id는 Query Service에서 생성
+                received.userId().toString(),
+                received.datingMeetingId().toString(),
+                received.joinedAt(),
+                "PARTICIPATED",
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/grewmeet/recording/recordingcommandservice/saga/outgoing/StudyParticipationRecorded.java
+++ b/src/main/java/com/grewmeet/recording/recordingcommandservice/saga/outgoing/StudyParticipationRecorded.java
@@ -1,5 +1,7 @@
 package com.grewmeet.recording.recordingcommandservice.saga.outgoing;
 
+import com.grewmeet.recording.recordingcommandservice.saga.incoming.StudyParticipationReceived;
+
 import java.time.LocalDateTime;
 
 public record StudyParticipationRecorded(
@@ -10,4 +12,16 @@ public record StudyParticipationRecorded(
     LocalDateTime participationDate,    // 참여 날짜
     String status,                      // 참여 상태
     LocalDateTime recordedAt            // 기록 생성 시간
-) {}
+) {
+    public static StudyParticipationRecorded from(StudyParticipationReceived received) {
+        return new StudyParticipationRecorded(
+                null,  // id는 Query Service에서 생성
+                received.userId().toString(),
+                received.studyMeetingId().toString(),
+                received.participantId().toString(),  // sessionId로 사용
+                received.completedAt(),
+                "ATTENDED",
+                LocalDateTime.now()
+        );
+    }
+}


### PR DESCRIPTION
  ## Summary
  - DatingParticipationEventListener, StudyParticipationEventListener 추가
  - OutboxPublisher를 service에서 event/publisher 패키지로 이동
  - OutboxPublisherImpl 구현체 분리
  - DatingParticipationRecorded, StudyParticipationRecorded에 from() 팩토리
  메서드 추가
  - 도메인별 이벤트 처리 로직 분리로 관심사 분리 개선

  ## Changes
  - ✨ 새로운 이벤트 리스너 패턴 도입
  - 🔄 패키지 구조 개선 (관심사 분리)
  - 🏗️ OutboxPublisher 구현체 분리